### PR TITLE
[FIX] Limit the number of digits in the rational numbers of EXIF latitude and longitude

### DIFF
--- a/starlingcaptureapi/exif.py
+++ b/starlingcaptureapi/exif.py
@@ -72,4 +72,8 @@ class Exif:
     def _to_rational(self, number):
         """Convert number to rational, (numerator, denominator)."""
         f = Fraction(number)
+        # Rounding ensures that the result fits in 4 bytes (es per EXIF spec),
+        # and also makes it so that the denominator will be a more
+        # human-friendly power of 10.
+        f = round(f, ndigits=10)
         return (f.numerator, f.denominator)

--- a/tests/test_claim.py
+++ b/tests/test_claim.py
@@ -92,12 +92,12 @@ def test_generates_create_claim(reverse_geocode_mocker):
     exif_assertion = assertions["stds.exif"]
     assert (
         exif_assertion["data"]["exif:GPSLatitude"]
-        == "15/1 55/1 3920383475626017/70368744177664"
+        == "15/1 55/1 6964/125"
     )
     assert exif_assertion["data"]["exif:GPSLatitudeRef"] == "S"
     assert (
         exif_assertion["data"]["exif:GPSLongitude"]
-        == "57/1 37/1 7625579331556737/140737488355328"
+        == "57/1 37/1 54183/1000"
     )
     assert exif_assertion["data"]["exif:GPSLongitudeRef"] == "W"
     assert exif_assertion["data"]["exif:GPSTimeStamp"] == "2021:10:30 18:43:14 +0000"
@@ -280,8 +280,8 @@ def test_prefers_current_latlon_with_fallback(reverse_geocode_mocker):
     assertions = _claim.assertions_by_label(claim)
     exif_assertion = assertions["stds.exif"]
     assert exif_assertion["data"] == {
-        "exif:GPSLatitude": "15/1 55/1 3920383475626017/70368744177664",
+        "exif:GPSLatitude": "15/1 55/1 6964/125",
         "exif:GPSLatitudeRef": "S",
-        "exif:GPSLongitude": "57/1 37/1 7625579331556737/140737488355328",
+        "exif:GPSLongitude": "57/1 37/1 54183/1000",
         "exif:GPSLongitudeRef": "W",
     }

--- a/tests/test_exif.py
+++ b/tests/test_exif.py
@@ -3,12 +3,12 @@ from .context import exif
 
 def test_convert_latitude():
     exif_lat = exif.Exif().convert_latitude(-15.9321422)
-    assert exif_lat == ("15/1 55/1 3920383475626017/70368744177664", "S")
+    assert exif_lat == ("15/1 55/1 6964/125", "S")
 
 
 def test_convert_longitude():
     exif_lon = exif.Exif().convert_longitude(-57.6317174)
-    assert exif_lon == ("57/1 37/1 7625579331556737/140737488355328", "W")
+    assert exif_lon == ("57/1 37/1 54183/1000", "W")
 
 def test_convert_timestamp():
     exif_ts = exif.Exif().convert_timestamp("2021-10-30T18:43:14Z")


### PR DESCRIPTION
This change ensures that we comply with the 4-byte requirement from the EXIF spec, and makes it so that the denominator for the seconds is more human-friendly.

Note that this implementation does _not_ guarantee that the denominator is always a power of ten (which is ideally human-readable), but merely makes it very likely. You can see examples in the tests of how the resulting values look.

This is the last step in completing https://github.com/starlinglab/starling-integrity-api/issues/21