### PR TITLE
Add date sub-directory to `create-output` and `create-proofmode-output` shared directory paths

### DIFF
--- a/starlingcaptureapi/actions.py
+++ b/starlingcaptureapi/actions.py
@@ -4,6 +4,7 @@ from .claim_tool import ClaimTool
 from .filecoin import Filecoin
 from . import config
 
+import datetime
 import json
 import logging
 import os
@@ -50,9 +51,12 @@ class Actions:
         # Copy the C2PA-injected asset to both the internal and shared asset directories.
         internal_asset_file = asset_helper.get_internal_file_fullpath(tmp_asset_file)
         shutil.move(tmp_asset_file, internal_asset_file)
-        subfolder = jwt_payload.get("author", {}).get("name")
+        subfolders = [
+            jwt_payload.get("author", {}).get("name"),
+            datetime.datetime.now().strftime("%Y-%m-%d"),
+        ]
         shutil.copy2(
-            internal_asset_file, asset_helper.get_assets_create_output(subfolder)
+            internal_asset_file, asset_helper.get_assets_create_output(subfolders)
         )
         _logger.info("New asset file added: %s", internal_asset_file)
         internal_claim_file = asset_helper.get_internal_claim_fullpath(
@@ -96,10 +100,13 @@ class Actions:
         # Copy the C2PA-injected asset to both the internal and shared asset directories.
         internal_asset_file = asset_helper.get_internal_file_fullpath(tmp_asset_file)
         shutil.move(tmp_asset_file, internal_asset_file)
-        subfolder = jwt_payload.get("author", {}).get("name")
+        subfolders = [
+            jwt_payload.get("author", {}).get("name"),
+            datetime.datetime.now().strftime("%Y-%m-%d"),
+        ]
         shutil.copy2(
             internal_asset_file,
-            asset_helper.get_assets_create_proofmode_output(subfolder),
+            asset_helper.get_assets_create_proofmode_output(subfolders),
         )
         _logger.info("New asset file added: %s", internal_asset_file)
         internal_claim_file = asset_helper.get_internal_claim_fullpath(
@@ -124,7 +131,9 @@ class Actions:
             the local path to the asset file in the internal directory
         """
         asset_helper = AssetHelper(organization_id)
-        return self._add(asset_fullpath, asset_helper.get_assets_add_output(), asset_helper)
+        return self._add(
+            asset_fullpath, asset_helper.get_assets_add_output(), asset_helper
+        )
 
     def update(self, organization_id, asset_fullpath):
         """Process asset with update action.
@@ -142,7 +151,7 @@ class Actions:
             asset_fullpath,
             _claim.generate_update(organization_id),
             asset_helper.get_assets_update_output(),
-            asset_helper
+            asset_helper,
         )
 
     def store(self, organization_id, asset_fullpath):
@@ -165,7 +174,7 @@ class Actions:
 
         return self._update(
             added_asset,
-            _claim.generate_store(ipfs_cid. organization_id),
+            _claim.generate_store(ipfs_cid.organization_id),
             AssetHelper(organization_id).get_assets_store_output(),
         )
 
@@ -198,7 +207,7 @@ class Actions:
             added_asset,
             _claim.generate_custom(custom_assertions),
             asset_helper.get_assets_custom_output(),
-            asset_helper
+            asset_helper,
         )
 
     def _add(self, asset_fullpath, output_dir, asset_helper):

--- a/starlingcaptureapi/asset_helper.py
+++ b/starlingcaptureapi/asset_helper.py
@@ -17,9 +17,7 @@ class AssetHelper:
                 part of directory names (e.g. "hyphacoop" good, not "Hypha Coop")
         """
         if self._filename_safe(organization_id) != organization_id:
-            raise ValueError(
-                f"Organization {organization_id} is not filename safe!"
-            )
+            raise ValueError(f"Organization {organization_id} is not filename safe!")
         self.org_id = organization_id
 
         # Organization-specific directory prefixes
@@ -106,23 +104,15 @@ class AssetHelper:
     def get_assets_add_output(self):
         return self.dir_add_output
 
-    def get_assets_create_output(self, subfolder=None):
-        if subfolder:
-            dir_subfolder = os.path.join(
-                self.dir_create_output, self._filename_safe(subfolder)
-            )
-            _file_util.create_dir(dir_subfolder)
-            return dir_subfolder
-        return self.dir_create_output
+    def get_assets_create_output(self, subfolders=[]):
+        return self._get_path_with_subfolders(
+            self.dir_create_output, subfolders=subfolders
+        )
 
-    def get_assets_create_proofmode_output(self, subfolder=None):
-        if subfolder:
-            dir_subfolder = os.path.join(
-                self.dir_create_proofmode_output, self._filename_safe(subfolder)
-            )
-            _file_util.create_dir(dir_subfolder)
-            return dir_subfolder
-        return self.dir_create_proofmode_output
+    def get_assets_create_proofmode_output(self, subfolders=[]):
+        return self._get_path_with_subfolders(
+            self.dir_create_proofmode_output, subfolders=subfolders
+        )
 
     def get_assets_update_output(self):
         return self.dir_update_output
@@ -174,3 +164,10 @@ class AssetHelper:
 
     def _filename_safe(self, filename):
         return filename.lower().replace(" ", "-").strip()
+
+    def _get_path_with_subfolders(self, full_path, subfolders=[]):
+        """Helper to add subfolders to path, create all directories if needed."""
+        for subfolder in subfolders:
+            full_path = os.path.join(full_path, self._filename_safe(subfolder))
+        _file_util.create_dir(full_path)
+        return full_path

--- a/tests/test_asset_helper.py
+++ b/tests/test_asset_helper.py
@@ -1,5 +1,6 @@
 import pytest
 
+from .context import config
 from .context import asset_helper
 
 
@@ -11,3 +12,17 @@ def test_rejects_non_file_safe_org():
 def test_directory_contains_org():
     helper = asset_helper.AssetHelper("example")
     assert helper.get_claims_internal() == "/tests/assets_dir/example/claims"
+
+def test_create_output_contains_subfolders(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "SHARED_FILE_SYSTEM", tmp_path / "shared_dir")
+
+    helper = asset_helper.AssetHelper("example")
+    assert helper.get_assets_create_output(["Jane Doe", "2022-02-17"]).endswith(
+        "/shared_dir/example/create-output/jane-doe/2022-02-17"
+    )
+
+def test_create_output_works_without_subfolders(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "SHARED_FILE_SYSTEM", tmp_path / "shared_dir")
+
+    helper = asset_helper.AssetHelper("example")
+    assert helper.get_assets_create_output().endswith("/shared_dir/example/create-output")


### PR DESCRIPTION
This change addresses https://github.com/starlinglab/starling-integrity-api/issues/52: adds a date sub-directory to the full directory path for the output directories of the `create` and `create-proofmode` actions.

The date used is the current date of the server (in the server's timezone, which is typically UTC) at the time of the action.

The resulting directory path looks like: `/tmp/shared_dir/hyphacoop/create-output/benedict-lau/2022-02-18`