### PR TITLE
HTTP client for the ISCN registration server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,4 @@ SHARED_FILE_SYSTEM="/path/to/fs_dir"
 CUSTOM_ASSERTIONS_DICTIONARY="/path/to/custom_assertions.json"
 WEB3_STORAGE_API_TOKEN="token you got from your https://web3.storage/ account"
 ORG_CONFIG_JSON="/path/to/config.json"  # see config.example.json for format
+ISCN_SERVER="http://localhost:3000"

--- a/Pipfile
+++ b/Pipfile
@@ -31,6 +31,7 @@ pytest = "*"
 # For mocking in tests
 pytest-mock = "*"
 pytest-env = "*"
+requests-mock = "*"
 
 [requires]
 python_version = "3.9"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "1d1390c32e7b720e626c563936c886a90c0682e1d82c2149ee8a1ceb1b36b04b"
+            "sha256": "5bde37cf2207f695a9240c05e8e19db1199b30589007871827ad970b0707a5c8"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -198,19 +198,19 @@
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:2842d8f5e82a1f6aa437380934d5e1cd4fcf2003b06fed6940769c164a480a45",
-                "sha256:98398a9d69ee80548c762ba991a4728bfc3836768ed226b3945908d1a688371c"
+                "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597",
+                "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"
             ],
-            "markers": "python_version >= '3'",
-            "version": "==2.0.11"
+            "markers": "python_version >= '3.5'",
+            "version": "==2.0.12"
         },
         "click": {
             "hashes": [
-                "sha256:353f466495adaeb40b6b5f592f9f91cb22372351c84caeb068132442a4518ef3",
-                "sha256:410e932b050f5eed773c4cda94de75971c89cdb3155a72a0831139a79e5ecb5b"
+                "sha256:6a7a62563bbfabfda3a38f3023a1db4a35978c0abd76f6c9605ecd6554d6d9b1",
+                "sha256:8458d7b1287c5fb128c90e23381cf99dcde74beaf6c7ff6384ce84d6fe090adb"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==8.0.3"
+            "version": "==8.0.4"
         },
         "decorator": {
             "hashes": [
@@ -617,13 +617,36 @@
             "index": "pypi",
             "version": "==22.1.0"
         },
+        "certifi": {
+            "hashes": [
+                "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872",
+                "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"
+            ],
+            "version": "==2021.10.8"
+        },
+        "charset-normalizer": {
+            "hashes": [
+                "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597",
+                "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==2.0.12"
+        },
         "click": {
             "hashes": [
-                "sha256:353f466495adaeb40b6b5f592f9f91cb22372351c84caeb068132442a4518ef3",
-                "sha256:410e932b050f5eed773c4cda94de75971c89cdb3155a72a0831139a79e5ecb5b"
+                "sha256:6a7a62563bbfabfda3a38f3023a1db4a35978c0abd76f6c9605ecd6554d6d9b1",
+                "sha256:8458d7b1287c5fb128c90e23381cf99dcde74beaf6c7ff6384ce84d6fe090adb"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==8.0.3"
+            "version": "==8.0.4"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff",
+                "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"
+            ],
+            "markers": "python_version >= '3'",
+            "version": "==3.3"
         },
         "iniconfig": {
             "hashes": [
@@ -656,11 +679,11 @@
         },
         "platformdirs": {
             "hashes": [
-                "sha256:30671902352e97b1eafd74ade8e4a694782bd3471685e78c32d0fdfd3aa7e7bb",
-                "sha256:8ec11dfba28ecc0715eb5fb0147a87b1bf325f349f3da9aab2cd6b50b96b692b"
+                "sha256:7535e70dfa32e84d4b34996ea99c5e432fa29a708d0f4e394bbcb2a8faa4f16d",
+                "sha256:bcae7cab893c2d310a711b70b24efb93334febe65f8de776ee320b517471e227"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.5.0"
+            "version": "==2.5.1"
         },
         "pluggy": {
             "hashes": [
@@ -688,11 +711,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:42901e6bd4bd4a0e533358a86e848427a49005a3256f657c5c8f8dd35ef137a9",
-                "sha256:dad48ffda394e5ad9aa3b7d7ddf339ed502e5e365b1350e0af65f4a602344b11"
+                "sha256:9ce3ff477af913ecf6321fe337b93a2c0dcf2a0a1439c43f5452112c1e4280db",
+                "sha256:e30905a0c131d3d94b89624a1cc5afec3e0ba2fbdb151867d8e0ebd49850f171"
             ],
             "index": "pypi",
-            "version": "==7.0.0"
+            "version": "==7.0.1"
         },
         "pytest-env": {
             "hashes": [
@@ -709,6 +732,30 @@
             "index": "pypi",
             "version": "==3.7.0"
         },
+        "requests": {
+            "hashes": [
+                "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61",
+                "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"
+            ],
+            "index": "pypi",
+            "version": "==2.27.1"
+        },
+        "requests-mock": {
+            "hashes": [
+                "sha256:0a2d38a117c08bb78939ec163522976ad59a6b7fdd82b709e23bb98004a44970",
+                "sha256:8d72abe54546c1fc9696fa1516672f1031d72a55a1d66c85184f972a24ba0eba"
+            ],
+            "index": "pypi",
+            "version": "==1.9.3"
+        },
+        "six": {
+            "hashes": [
+                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.16.0"
+        },
         "tomli": {
             "hashes": [
                 "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
@@ -719,11 +766,19 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:4ca091dea149f945ec56afb48dae714f21e8692ef22a395223bcd328961b6a0e",
-                "sha256:7f001e5ac290a0c0401508864c7ec868be4e701886d5b573a9528ed3973d9d3b"
+                "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42",
+                "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2"
             ],
             "markers": "python_version < '3.10'",
-            "version": "==4.0.1"
+            "version": "==4.1.1"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed",
+                "sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "version": "==1.26.8"
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The server is configured entirely via environment variables. See [config.py](./s
 Most importantly, you will need to provide:
 * `CLAIM_TOOL_PATH`: A path to a fully working `claim_tool` binary. The server should have permissions to execute it, and it should be correctly configured with its keys.
 * `IMAGES_DIR`: A path to a directory to store images. The server will need write access to this directory. This will be the persistent storage for the received images with their attestations.
+* `ISCN_SERVER`: The instance of the ISCN server to send registration requests to. Typically, this will be `http://localhost:3000` if you are using the sample server at https://github.com/likecoin/iscn-js/tree/master/sample/server in its default configuration.
 
 ## Development
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,4 @@ env =
   RUN_ENV=test
   INTERNAL_ASSET_STORE=/tests/assets_dir
   SHARED_FILE_SYSTEM=/tests/shared_dir
+  ISCN_SERVER=http://localhost:3000

--- a/starlingcaptureapi/config.py
+++ b/starlingcaptureapi/config.py
@@ -25,6 +25,9 @@ CUSTOM_ASSERTIONS_DICTIONARY = os.environ.get("CUSTOM_ASSERTIONS_DICTIONARY")
 # API token for the web3.storage service
 WEB3_STORAGE_API_TOKEN = os.environ.get("WEB3_STORAGE_API_TOKEN")
 
+# Address of ISCN registration HTTP server to use
+ISCN_SERVER = os.environ.get("ISCN_SERVER")
+
 
 class OrganizationConfig:
     def __init__(self, config_file):

--- a/starlingcaptureapi/iscn.py
+++ b/starlingcaptureapi/iscn.py
@@ -1,0 +1,32 @@
+from . import config
+
+import logging
+import requests
+
+_logger = logging.getLogger(__name__)
+_REGISTER = f"{config.ISCN_SERVER}/iscn/new/"
+
+
+class Iscn:
+    """Handles interactions with ISCN"""
+
+    @staticmethod
+    def register(registration: dict) -> bool:
+        """Registers an asset on ISCN with the provided metadata.
+
+        Args:
+            registration: the complete contents of the ISCN registration; must comply with the
+                ISCN schema (https://github.com/likecoin/iscn-specs/tree/master/schema)
+
+        Returns:
+            True if the registration succeeded; False otherwise
+        """
+        response = requests.post(_REGISTER, json={"metadata": registration})
+
+        if not response.ok:
+            _logger.error(
+                "ISCN registration failed: %s %s", response.status_code, response.text
+            )
+            return False
+
+        return True

--- a/tests/context.py
+++ b/tests/context.py
@@ -9,3 +9,4 @@ from starlingcaptureapi import claim
 from starlingcaptureapi import config
 from starlingcaptureapi import exif
 from starlingcaptureapi import geocoder
+from starlingcaptureapi import iscn

--- a/tests/test_iscn.py
+++ b/tests/test_iscn.py
@@ -1,0 +1,14 @@
+from .context import iscn
+
+
+def test_register_success(requests_mock):
+    registration = {"foo": 123, "bar": "other stuff"}
+    requests_mock.post(iscn._REGISTER, status_code=200)
+    assert iscn.Iscn.register(registration)
+    assert len(requests_mock.request_history) == 1
+    assert requests_mock.last_request.json() == {"metadata": registration}
+
+
+def test_register_failure(requests_mock):
+    requests_mock.post(iscn._REGISTER, status_code=500)
+    assert not iscn.Iscn.register({})


### PR DESCRIPTION
This PR addresses https://github.com/starlinglab/starling-integrity-api/issues/53 by providing a library that wraps the call to an HTTP server that acts as a proxy for ISCN registration.

The server is expected to be an instance of https://github.com/likecoin/iscn-js/tree/master/sample/server which holds the wallet that will "sign" the registration. To run this server, after doing `npm install`, invoke: `$ MNEMONIC_SEED_WORD=<your wallet mnemonic> node src/index.js`.

The `registration` dictionary itself will have a schema like the one discussed in https://github.com/starlinglab/starling-integrity-api/issues/53#issuecomment-1058107379 . We will implement assembling this registration object once we are ready to wire the yet-to-be-written "batcher" code to the ISCN registration.

With this change and a locally running ISCN registration server, it is possible to do a registration with:
```
# Enter our Python environment
$ pipenv shell
$ python
>>> from starlingcaptureapi.iscn import Iscn
>>> Iscn.register(<your registration dict>)
```

An example registration looks something like (see https://github.com/starlinglab/starling-integrity-api/issues/53#issuecomment-1058107379 for a detailed discussion of what we intend this to look like, although for testing you can do something simpler):
```
{
    "recordNotes": "Initial registration.",
    "contentFingerprints": [
        "ipfs://<SOME_CID>"
    ],
    "contentMetadata": {
        "@context": "https://schema.org",
        "@type": "CreativeWork",
        "name": "<SOME NAME STRING>",
        "description": "<SOME DESCRIPTION>",
        "author": "https://starlinglab.org",
        "keywords": "foo, bar"
        "conditionsOfAccess": "Encrypted with AES-128."
    }
}
```