### PR TITLE
CIDv1 generation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # To use in development, copy this into .env, and edit with the settings for your environment.
 
 JWT_SECRET="super-seekret"
-CLAIM_TOOL_PATH="/path/to/binary/claim_tool"
+CLAIM_TOOL_PATH="/path/to/claim_tool"
 IPFS_BIN_PATH="/path/to/ipfs"
 INTERNAL_ASSET_STORE="/path/to/assets_dir"
 SHARED_FILE_SYSTEM="/path/to/fs_dir"

--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 
 JWT_SECRET="super-seekret"
 CLAIM_TOOL_PATH="/path/to/binary/claim_tool"
+IPFS_BIN_PATH="/path/to/ipfs"
 INTERNAL_ASSET_STORE="/path/to/assets_dir"
 SHARED_FILE_SYSTEM="/path/to/fs_dir"
 CUSTOM_ASSERTIONS_DICTIONARY="/path/to/custom_assertions.json"

--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 
 JWT_SECRET="super-seekret"
 CLAIM_TOOL_PATH="/path/to/claim_tool"
-IPFS_BIN_PATH="/path/to/ipfs"
+IPFS_CLIENT_PATH="/path/to/ipfs"
 INTERNAL_ASSET_STORE="/path/to/assets_dir"
 SHARED_FILE_SYSTEM="/path/to/fs_dir"
 CUSTOM_ASSERTIONS_DICTIONARY="/path/to/custom_assertions.json"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ The Starling Integrity API provides HTTP endpoints for creating integrity attest
 
 It depends on a binary of Adobe's `claim_tool`, which is planned to be open-sourced.
 
+Other required binaries:
+- `ipfs` from https://ipfs.io
+
 ## Configuration
 
 The server is configured entirely via environment variables. See [config.py](./starlingcaptureapi/config.py) for the available variables and some notes about each. In development, you can use a local `.env` file setting environment variables. See `.env.example` for an example.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The Starling Integrity API provides HTTP endpoints for creating integrity attest
 It depends on a binary of Adobe's `claim_tool`, which is planned to be open-sourced.
 
 Other required binaries:
-- `ipfs` from https://ipfs.io
+- `ipfs` from [ipfs.io](https://ipfs.io)
 
 ## Configuration
 

--- a/starlingcaptureapi/config.py
+++ b/starlingcaptureapi/config.py
@@ -13,8 +13,8 @@ JWT_SECRET = os.environ.get("JWT_SECRET")
 # Full path to claim_tool binary. Must be already configured.
 CLAIM_TOOL_PATH = os.environ.get("CLAIM_TOOL_PATH")
 
-# Full path to IPFS binary. Must be already configured.
-IPFS_BIN_PATH = os.environ.get("IPFS_BIN_PATH")
+# Full path to IPFS client binary. Must be already configured.
+IPFS_CLIENT_PATH = os.environ.get("IPFS_CLIENT_PATH")
 
 # Local directory for storing internal assets. Must exist and be readable by the server.
 INTERNAL_ASSET_STORE = os.environ.get("INTERNAL_ASSET_STORE")

--- a/starlingcaptureapi/config.py
+++ b/starlingcaptureapi/config.py
@@ -13,6 +13,9 @@ JWT_SECRET = os.environ.get("JWT_SECRET")
 # Full path to claim_tool binary. Must be already configured.
 CLAIM_TOOL_PATH = os.environ.get("CLAIM_TOOL_PATH")
 
+# Full path to IPFS binary. Must be already configured.
+IPFS_BIN_PATH = os.environ.get("IPFS_BIN_PATH")
+
 # Local directory for storing internal assets. Must exist and be readable by the server.
 INTERNAL_ASSET_STORE = os.environ.get("INTERNAL_ASSET_STORE")
 

--- a/starlingcaptureapi/file_util.py
+++ b/starlingcaptureapi/file_util.py
@@ -4,8 +4,8 @@ from hashlib import sha256
 import errno
 import logging
 import os
-import uuid
 import subprocess
+import uuid
 
 _logger = logging.getLogger(__name__)
 

--- a/starlingcaptureapi/file_util.py
+++ b/starlingcaptureapi/file_util.py
@@ -67,6 +67,9 @@ class FileUtil:
 
         Returns:
             CIDv1 in the canonical string format
+
+        Raises:
+            Exception if errors are encountered during processing
         """
 
         if not os.path.exists(os.path.expanduser("~/.ipfs")):

--- a/starlingcaptureapi/file_util.py
+++ b/starlingcaptureapi/file_util.py
@@ -59,7 +59,8 @@ class FileUtil:
             return hasher.hexdigest()
         # TODO: handle error (image not found, etc.)
 
-    def cidv1(self, file_path):
+    @staticmethod
+    def digest_cidv1(self, file_path):
         """Generates the CIDv1 of a file, as determined by ipfs add.
 
         Args:

--- a/starlingcaptureapi/file_util.py
+++ b/starlingcaptureapi/file_util.py
@@ -99,7 +99,7 @@ class FileUtil:
 
         if proc.returncode != 0:
             raise Exception(
-                f"'ipfs init' failed with code {proc.returncode} and output:\n\n{proc.stdout}"
+                f"'ipfs add --only-hash --cid-version=1' failed with code {proc.returncode} and output:\n\n{proc.stdout}"
             )
 
         return proc.stdout.strip()

--- a/starlingcaptureapi/file_util.py
+++ b/starlingcaptureapi/file_util.py
@@ -89,7 +89,7 @@ class FileUtil:
 
         proc = subprocess.run(
             [
-                config.IPFS_BIN_PATH,
+                config.IPFS_CLIENT_PATH,
                 "add",
                 "--only-hash",
                 "--cid-version=1",


### PR DESCRIPTION
Closes #63 by adding a small function that shells out to `ipfs add`. It creates an IPFS repo when needed, as that's required for `ipfs add` to work.