### PR TITLE
Fix server startup on Mac OS X

### DIFF
--- a/main.py
+++ b/main.py
@@ -89,12 +89,12 @@ if __name__ == "__main__":
     for org_id in config.ORGANIZATION_CONFIG.all_orgs():
         _procs.append(
             multiprocessing.Process(
-                name="proc_fs_watcher", target=lambda: start_fs_watcher(org_id)
+                name=f"fs_watcher_{org_id}", target=start_fs_watcher, args=(org_id,)
             )
         )
 
     proc_api_server = multiprocessing.Process(
-        name="proc_api_server", target=start_api_server
+        name="api_server", target=start_api_server
     )
     _procs.append(proc_api_server)
 


### PR DESCRIPTION
Addresses https://github.com/starlinglab/starling-integrity-api/issues/60, which is actually a broader bug that for some reason works on Debian Bullseye.

The underlying issue is that when a `target` is passed to `multiprocessing.Process`, the library internally "pickles" it, which means that the `target` needs to pickleable. When PR https://github.com/starlinglab/starling-integrity-api/pull/55/files made `target` a `lambda` function, this broke, because `lambda`s are non-pickeable (only non-lambda top-level functions in a module are pickeable, according to https://docs.python.org/3/library/pickle.html#what-can-be-pickled-and-unpickled).

This change fixes the way we were calling `multiprocessing.Process(...)` by providing the arguments to our target function in the `args` parameter for the Process.