### PR TITLE
Add digest_md5

### DIFF
--- a/starlingcaptureapi/file_util.py
+++ b/starlingcaptureapi/file_util.py
@@ -2,7 +2,7 @@ from . import config
 from .crypto_util import AESCipher
 
 from Crypto.Cipher import AES
-from hashlib import sha256
+from hashlib import sha256, md5
 
 import errno
 import logging
@@ -53,14 +53,35 @@ class FileUtil:
 
         Returns:
             the HEX-encoded SHA-256 digest of the input file
+
+        Raises:
+            any file I/O errors
         """
         hasher = sha256()
         with open(file_path, "rb") as f:
             # Parse file in blocks
-            for byte_block in iter(lambda: f.read(4096), b""):
+            for byte_block in iter(lambda: f.read(32 * 1024), b""):
                 hasher.update(byte_block)
             return hasher.hexdigest()
-        # TODO: handle error (image not found, etc.)
+
+    def digest_md5(self, file_path):
+        """Generates MD5 digest of a file.
+
+        Args:
+            file_path: the local path to a file
+
+        Returns:
+            the HEX-encoded MD5 digest of the input file
+
+        Raises:
+            any file I/O errors
+        """
+        hasher = md5()
+        with open(file_path, "rb") as f:
+            # Parse file in blocks
+            for byte_block in iter(lambda: f.read(32 * 1024), b""):
+                hasher.update(byte_block)
+            return hasher.hexdigest()
 
     def register_timestamp(self, file_path, ts_file_path, timeout=5, min_cals=2):
         """Creates a opentimestamps file for the given file.

--- a/starlingcaptureapi/file_util.py
+++ b/starlingcaptureapi/file_util.py
@@ -190,10 +190,10 @@ class FileUtil:
             iv = enc.read(16)
             cipher = AESCipher(key, iv)
 
-            data = enc.read(BUFFER_SIZE / 2)
+            data = enc.read(int(BUFFER_SIZE / 2))
             while True:
                 prev_data = data
-                data = enc.read(BUFFER_SIZE / 2)
+                data = enc.read(int(BUFFER_SIZE / 2))
 
                 if len(data) == 0:
                     # prev_data is the final block in the file and is therefore padded

--- a/starlingcaptureapi/file_util.py
+++ b/starlingcaptureapi/file_util.py
@@ -48,6 +48,34 @@ class FileUtil:
         """
         return str(uuid.uuid4())
 
+    def digest(self, algo, file_path):
+        """Generates cryptographic hash digest of a file.
+
+        Args:
+            algo: A string representing the hash algorithm. ("sha256", "md5")
+            file_path: the local path to a file
+
+        Returns:
+            the HEX-encoded digest of the input file
+
+        Raises:
+            any file I/O errors
+            NotImplementedError for an unknown hash algo
+        """
+
+        if algo == "sha256":
+            hasher = sha256()
+        elif algo == "md5":
+            hasher = md5()
+        else:
+            raise NotImplementedError(f"unknown hash algo {algo}")
+
+        with open(file_path, "rb") as f:
+            # Parse file in blocks
+            for byte_block in iter(lambda: f.read(BUFFER_SIZE), b""):
+                hasher.update(byte_block)
+            return hasher.hexdigest()
+
     def digest_sha256(self, file_path):
         """Generates SHA-256 digest of a file.
 
@@ -60,12 +88,8 @@ class FileUtil:
         Raises:
             any file I/O errors
         """
-        hasher = sha256()
-        with open(file_path, "rb") as f:
-            # Parse file in blocks
-            for byte_block in iter(lambda: f.read(BUFFER_SIZE), b""):
-                hasher.update(byte_block)
-            return hasher.hexdigest()
+
+        return self.digest("sha256", file_path)
 
     def digest_md5(self, file_path):
         """Generates MD5 digest of a file.
@@ -79,12 +103,8 @@ class FileUtil:
         Raises:
             any file I/O errors
         """
-        hasher = md5()
-        with open(file_path, "rb") as f:
-            # Parse file in blocks
-            for byte_block in iter(lambda: f.read(BUFFER_SIZE), b""):
-                hasher.update(byte_block)
-            return hasher.hexdigest()
+
+        return self.digest("md5", file_path)
 
     def register_timestamp(self, file_path, ts_file_path, timeout=5, min_cals=2):
         """Creates a opentimestamps file for the given file.

--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -1,0 +1,17 @@
+from .context import file_util
+
+fu = file_util.FileUtil()
+
+# https://docs.pytest.org/en/latest/how-to/tmp_path.html
+
+
+def test_digest(tmp_path):
+    unhashed = tmp_path / "unhashed.txt"
+    unhashed.write_text("hello world")
+
+    assert (
+        fu.digest_sha256(str(unhashed))
+        == "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+    )
+
+    assert fu.digest_md5(str(unhashed)) == "5eb63bbbe01eeed093cb22bb8f5acdc3"


### PR DESCRIPTION
Closes #71

This also updates the other digest function to use a 32 KiB buffer instead of the 4 KiB one. This should improve hashing speed. This specific number is taken from Go stdlib, where `io.Copy` uses a 32 KiB buffer if needed. The perfect buffer size for a Linux system varies, but this should be good enough, and better than before.