### PR TITLE
Numbers protocol

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,4 @@ WEB3_STORAGE_API_TOKEN="token you got from your https://web3.storage/ account"
 ORG_CONFIG_JSON="/path/to/config.json"  # see config.example.json for format
 OTS_CLIENT_PATH="/path/to/ots"
 ISCN_SERVER="http://localhost:3000"
+NUMBERS_API_KEY="api key from Numbers"

--- a/starlingcaptureapi/config.py
+++ b/starlingcaptureapi/config.py
@@ -34,6 +34,8 @@ OTS_CLIENT_PATH = os.environ.get("OTS_CLIENT_PATH")
 # Address of ISCN registration HTTP server to use
 ISCN_SERVER = os.environ.get("ISCN_SERVER")
 
+NUMBERS_API_KEY = os.environ.get("NUMBERS_API_KEY")
+
 
 class OrganizationConfig:
     def __init__(self, config_file):

--- a/starlingcaptureapi/numbers.py
+++ b/starlingcaptureapi/numbers.py
@@ -1,4 +1,3 @@
-from msilib.schema import File
 from . import config
 from .file_util import FileUtil
 

--- a/starlingcaptureapi/numbers.py
+++ b/starlingcaptureapi/numbers.py
@@ -1,0 +1,70 @@
+from msilib.schema import File
+from . import config
+from .file_util import FileUtil
+
+import logging
+import requests
+
+_logger = logging.getLogger(__name__)
+
+file_util = FileUtil()
+
+_COMMIT_URL = "https://node.numbersprotocol.io/version-test/api/1.1/wf/commit"
+
+
+def commit(asset, asset_tree, author):
+    """Register a commit to the integrity blockchain.
+
+    https://github.com/numbersprotocol/enterprise-service/wiki/Web-3.0-API#nit-commit
+
+    Args:
+        asset: path to the asset file
+        asset_tree: path to asset JSON
+        author: path to author JSON
+
+    Raises:
+        any file I/O errors
+        JSON decoding errors
+
+    Returns:
+        Transaction hash string. If registration fails it returns None.
+    """
+
+    asset_cid = file_util.digest_cidv1(asset)
+    asset_tree_cid = file_util.digest_cidv1(asset_tree)
+    asset_tree_sha = file_util.digest_sha256(asset_tree)
+    author_cid = file_util.digest_cidv1(author)
+
+    r = requests.post(
+        _COMMIT_URL,
+        headers={"Authorization", f"Bearer {config.NUMBERS_API_KEY}"},
+        files=[
+            ("assetCid", asset_cid),
+            ("assetTreeCid", asset_tree_cid),
+            ("assetTreeSha256", asset_tree_sha),
+            ("author", author_cid),
+            ("action", "testAction"),  # Will change in the future!
+            ("actionResult", "testActionResult"),  # Will change in the future!
+            ("dryRun", "false"),
+            ("mockup", "false"),
+        ],
+    )
+
+    if not r.ok:
+        _logger.error("Numbers commit failed: %s %s", r.status_code, r.text)
+        return None
+
+    data = r.json()
+
+    if data.get("response") is None:
+        _logger.warning(
+            "Numbers commit response did not have the 'response' field: %s", r.text
+        )
+        return None
+    if data["response"].get("txHash") is None:
+        _logger.warning(
+            "Numbers commit response did not have the 'txHash' field: %s", r.text
+        )
+        return None
+
+    return data["response"]["txHash"]

--- a/tests/context.py
+++ b/tests/context.py
@@ -15,3 +15,4 @@ from starlingcaptureapi import iscn
 from starlingcaptureapi import file_util
 from starlingcaptureapi import crypto_util
 from starlingcaptureapi import zip_util
+from starlingcaptureapi import numbers

--- a/tests/context.py
+++ b/tests/context.py
@@ -15,4 +15,3 @@ from starlingcaptureapi import iscn
 from starlingcaptureapi import file_util
 from starlingcaptureapi import crypto_util
 from starlingcaptureapi import zip_util
-from starlingcaptureapi import numbers


### PR DESCRIPTION
Handles part of #56, adding code to register assets using the Numbers protocol on Avalanche.

Let me know if other API calls should be supported, they can all be seen [here](https://github.com/numbersprotocol/enterprise-service/wiki/Web-3.0-API).

I wasn't able to create tests for this, as the function relies on generating a CIDv1, which requires an `ipfs` binary that the CI doesn't have.